### PR TITLE
fix routing in config/redirects

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,4 +1,4 @@
-define: prefix /docs/languages/java/drivers/java-rs
+define: prefix docs/languages/java/reactive-streams-driver
 define: base https://www.mongodb.com/${prefix}
 define: versions main
 


### PR DESCRIPTION
# Pull Request Info

This site originally had a different prefix path. Now, with a fully corrected URL Mapping in this document, we can change this driver to the correct path.

I am opening another [PR in docs-ecosystem](https://github.com/mongodb/docs-ecosystem/pull/962) to address the links to this docs property site, as well. (Although, I will keep the old location of the S3 files up just in case there's an overlap in the change with docs-ecosystem).