### PR TITLE
DOCSP-42282: java avs type support in v5.2

### DIFF
--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -37,7 +37,7 @@ New features of the 5.2 driver release include:
 
    .. replacement:: avs-index-link
 
-      the `SearchIndexModel <{+api+}/mongodb-driver-core/com/mongodb/ConnectionString.html>`__
+      the `SearchIndexModel <{+api+}/mongodb-driver-core/com/mongodb/client/model/SearchIndexModel.html>`__
       API documentation
 
 .. _javars-version-5.1.3:

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -20,10 +20,25 @@ What's New
 Learn about new features, improvements, and fixes introduced in the
 following versions of the {+driver-long+}:
 
+* :ref:`Version 5.2 <javars-version-5.2>`
 * :ref:`Version 5.1.3 <javars-version-5.1.3>`
 * :ref:`Version 5.1.2 <javars-version-5.1.2>`
 * :ref:`Version 5.1.1 <javars-version-5.1.1>`
 * :ref:`Version 5.1 <javars-version-5.1>`
+
+.. _javars-version-5.2:
+
+What's New in 5.2
+-----------------
+
+New features of the 5.2 driver release include:
+
+.. sharedinclude:: dbx/jvm/v5.2-wn-items.rst
+
+   .. replacement:: avs-index-link
+
+      the `SearchIndexModel <{+api+}/mongodb-driver-core/com/mongodb/ConnectionString.html>`__
+      API documentation
 
 .. _javars-version-5.1.3:
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java-rs/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-42282>
Staging - https://preview-mongodbrustagir.gatsbyjs.io/java-rs/DOCSP-42282-avs-index-type/whats-new/#what-s-new-in-5.2

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
