### PR TITLE
Add missing meta descriptions

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -10,6 +10,7 @@ MongoDB Java Reactive Streams Documentation
 
 .. meta::
    :keywords: home
+   :description: Explore resources and tutorials for using the Java Reactive Streams driver to connect, read, write, and optimize data operations with MongoDB.
 
 .. contents:: On this page
    :local:

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -10,6 +10,7 @@ What's New
 
 .. meta::
    :keywords: update, new feature, deprecation, upgrade
+   :description: Discover new features, improvements, and fixes in recent versions of the Java Reactive Streams Driver, including updates on vector storage, connection pool, and authentication.
 
 .. contents:: On this page
    :local:


### PR DESCRIPTION
Adds missing meta descriptions generated by the Education AI Team\n\nSOURCE: https://docs.google.com/spreadsheets/d/1fdrjF4Ms9fMl96zLiLGsYD_V38rTfPLuKs5VQk4vz6E/edit?gid=1166644539