### PR TITLE
[backport v5.5] DOCSP-49013 BOM Tips added to Java RS (#136)

### DIFF
--- a/source/includes/security/crypt-gradle-versioned.rst
+++ b/source/includes/security/crypt-gradle-versioned.rst
@@ -1,5 +1,5 @@
 .. code-block:: groovy
 
    dependencies {
-      implementation 'org.mongodb:mongodb-crypt:{+full-version+}'
+      implementation 'org.mongodb:mongodb-crypt'
    }

--- a/source/includes/security/crypt-maven-versioned.rst
+++ b/source/includes/security/crypt-maven-versioned.rst
@@ -4,6 +4,5 @@
        <dependency>
            <groupId>org.mongodb</groupId>
            <artifactId>mongodb-crypt</artifactId>
-           <version>{+full-version+}</version>
        </dependency>
    </dependencies>

--- a/source/security/encrypt.txt
+++ b/source/security/encrypt.txt
@@ -4,25 +4,32 @@
 
    .. replacement:: driver-specific-content
 
-      .. important:: Compatible Encryption Library Version
+      Compatible Encryption Library Version
+      -------------------------------------
 
-         The {+driver-short+} uses the `mongodb-crypt
-         <https://mvnrepository.com/artifact/org.mongodb/mongodb-crypt>`__
-         encryption library for in-use encryption. This driver version
-         is compatible with ``mongodb-crypt`` v{+full-version+}.
+      The {+driver-short+} uses the `mongodb-crypt
+      <https://mvnrepository.com/artifact/org.mongodb/mongodb-crypt>`__
+      encryption library for in-use encryption. This driver version
+      is compatible with ``mongodb-crypt`` v{+full-version+}.
 
-         Select from the following :guilabel:`Maven` and
-         :guilabel:`Gradle` tabs to see how to add the ``mongodb-crypt``
-         dependency to your project by using the specified manager:
-         
-         .. tabs::
-         
-            .. tab:: Maven
-               :tabid: maven-dependency
-         
-               .. include:: /includes/security/crypt-maven-versioned.rst
-         
-            .. tab:: Gradle
-               :tabid: gradle-dependency
-         
-               .. include:: /includes/security/crypt-gradle-versioned.rst
+      .. sharedinclude:: dbx/jvm/BOM-installation-tip.rst
+
+         .. replacement:: installation-guide
+
+            :ref:`Add the Driver Bill of Materials <java-rs-get-started-install-bom>` step of the Download and Install guide.
+
+      Select from the following :guilabel:`Maven` and
+      :guilabel:`Gradle` tabs to see how to add the ``mongodb-crypt``
+      dependency to your project by using the specified manager:
+      
+      .. tabs::
+      
+         .. tab:: Maven
+            :tabid: maven-dependency
+      
+            .. include:: /includes/security/crypt-maven-versioned.rst
+      
+         .. tab:: Gradle
+            :tabid: gradle-dependency
+      
+            .. include:: /includes/security/crypt-gradle-versioned.rst


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `v5.5`:
 - [DOCSP-49013 BOM Tips added to Java RS (#136)](https://github.com/mongodb/docs-java-rs/pull/136)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)