### PR TITLE
[v5.5] DOCSP-45102 Document lack of support for domain socket connections (#141)

### DIFF
--- a/source/connect.txt
+++ b/source/connect.txt
@@ -144,6 +144,8 @@ You can connect to multiple ``mongos`` instances in the following ways:
                      new ServerAddress("<second hostname", <second port>))))
              .build());
 
+.. include:: /includes/connect/domain-socket.rst
+
 Connection Options
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/includes/connect/domain-socket.rst
+++ b/source/includes/connect/domain-socket.rst
@@ -1,0 +1,8 @@
+.. important:: 
+
+    The {+driver-short+} does not support `UnixServerAddress
+    <{+core-api+}/UnixServerAddress.html>`__ objects or domain socket
+    connections. To use a domain socket to connect, use the :driver:`Java Sync
+    driver. </java/sync/current/>` Otherwise, use a `ServerAddress
+    <{+core-api+}/ServerAddress.html>`__ object to connect from the
+    {+driver-short+}.

--- a/source/security/auth.txt
+++ b/source/security/auth.txt
@@ -61,6 +61,8 @@ credential by using the ``createCredential()`` static factory method:
            .credential(credential)
            .build());
 
+.. include:: /includes/connect/domain-socket.rst
+
 Or, you can use a connection string without explicitly specifying the
 authentication mechanism:
 

--- a/source/security/enterprise-authentication.txt
+++ b/source/security/enterprise-authentication.txt
@@ -52,6 +52,8 @@ connection settings.  Select the
 :guilabel:`MongoCredential` tab in the following sections to see the syntax for
 authenticating using a ``MongoCredential``.
 
+.. include:: /includes/connect/domain-socket.rst
+
 Mechanisms
 ----------
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -178,15 +178,6 @@ This driver version introduces the following breaking changes:
   Instead of ``getSocketAddresses()``, use the ``getAllByName()`` instance
   method of ``java.net.InetAddress``.
 
-- Removes the `UnixServerAddress <{+core-api+}/UnixServerAddress.html>`__
-  methods ``getSocketAddress()`` and ``getUnixSocketAddress()``.
-
-  Instead of ``getUnixSocketAddress()``, construct an instance of
-  ``jnr.unixsocket.UnixSocketAddress``. Pass the full path of the UNIX
-  socket file to the constructor. By default, MongoDB creates a UNIX
-  socket file located at ``"/tmp/mongodb-27017.sock"``. To learn more
-  about the ``UnixSocketAddress``, see the `UnixSocketAddress <https://www.javadoc.io/doc/com.github.jnr/jnr-unixsocket/latest/jnr/unixsocket/UnixSocketAddress.html>`__ API documentation.
-
 - Removes the ``Parameterizable`` interface. Instead of
   implementing this interface on a custom ``Codec`` type,
   override the ``CodecProvider.get()`` method on the


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `v5.5`:
 - [DOCSP-45102 Document lack of support for domain socket connections (#141)](https://github.com/mongodb/docs-java-rs/pull/141)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)